### PR TITLE
Reset tune_on variable on abort or reset command.

### DIFF
--- a/src/winkeydaemon
+++ b/src/winkeydaemon
@@ -388,6 +388,7 @@ sub Do_operations {
 		    my $stopkeying = sprintf("%c", 0x0A);
 		    $count = $port->write($stopkeying);
                     @fifo = ();
+		    $tune_on = 0;
 		}
 
 	    } else {


### PR DESCRIPTION
Abort or Reset comamnd stops keying and flushes text buffer.
It should also clean up the 'tune_on' variable. Otherwise the next
Tune command will be ignored.