### PR TITLE
Improve cwdaemon compatibility

### DIFF
--- a/src/winkeydaemon
+++ b/src/winkeydaemon
@@ -255,8 +255,6 @@ $port->stopbits(2)    || die "$0: could not set stop bits.\n";
 $port->dtr_active(1)  || die "$0: could not set DTR.\n";
 $port->rts_active(0)  || die "$0: could not set RTS.\n";
 
-my $timeout = 0;
-
 $port->read_char_time(0);
 $port->read_const_time(1);
 
@@ -268,10 +266,9 @@ my $server = IO::Socket::INET->new(LocalPort => $server_port, Proto => "udp")
 
 ########### Initialize keyer
 
-my $openKeyer = sprintf("%c%c", 0x00, 0x02);	## open keyer interface
-my $count = $port->write($openKeyer);
+my $count = port_write(0x00, 0x02);     ## open keyer interface
 
-select undef,undef,undef, 0.3;
+delay_ms(300);
 
 ## set mode: normal word space, no autospace, serial echo,
 ##           iambic-B,  paddle echo as requested by '-e' , paddle watchdog.
@@ -280,33 +277,27 @@ if (defined $opt_e) {
   $winKeyerMode = 0xC4; # Paddle echo
 }
 
-my $setmode = sprintf ("%c%c", 0x0E, $winKeyerMode);
-$count = $port->write($setmode);
+$count = port_write(0x0E, $winKeyerMode);
 
-select undef,undef,undef, 0.3;
+delay_ms(300);
 
-$setmode = sprintf ("%c%c", 0x03, 0x32); ## weighting: none = 0x32
-$count = $port->write($setmode);
+$count = port_write(0x03, 0x32);        ## weighting: none = 0x32
 
-select undef,undef,undef, 0.3;
+delay_ms(300);
 
-my $setpins = sprintf ("%c%c", 0x09, $pinCfg); ## set pinout: LED=side-tone
-$count = $port->write($setpins);
+$count = port_write(0x09, $pinCfg);     ## set pinout: LED=side-tone
 
-select undef,undef,undef, 0.2;
+delay_ms(200);
 
-my $senddelay = sprintf ("%c%c%c", 0x04, 0x01, 0x00); ## set PTT lead. tail [ms]
-$count = $port->write($senddelay);
+$count = port_write(0x04, 0x01, 0x00);  ## set PTT lead. tail [ms]
 
-select undef,undef,undef, 0.2;
+delay_ms(200);
 
 ## set min  WPM and speed range:
 my $r = $maxSpeed - $minSpeed;
-my $setRange = sprintf ("%c%c%c%c", 0x05, $minSpeed, $r, 0);
-$count = $port->write($setRange);
+$count = port_write(0x05, $minSpeed, $r, 0);    ## set range
 
-my $setspeed = sprintf ("%c%c", 0x02, $speed);  ## set the default speed
-$count = $port->write($setspeed);
+$count = port_write(0x02, $speed);      ## set the default speed
 
 if ($debug) {
 	Do_operations();	## do not fork, debug
@@ -325,6 +316,20 @@ if ($debug) {
 
 exit;
 
+#
+# delay N milliseconds
+#
+sub delay_ms {
+    my $ms = shift;
+    select undef,undef,undef, $ms / 1000;
+}
+
+#
+# write an array of bytes to the serial port
+#
+sub port_write {
+    return $port->write(pack 'C*', @_);
+}
 
 ########## Start operations ########
 sub Do_operations {
@@ -382,8 +387,7 @@ sub Do_operations {
 		    }
 
 		    if ($debug) {print "setspeed=$speed\n";}
-		    $setspeed = sprintf ("%c%c", 0x02, $speed);
-		    $count = $port->write($setspeed);
+		    $count = port_write(0x02, $speed);
 
 		} elsif ($cmd eq "5") {     ## exit daemon
 		    if ($debug) {print "Exiting\n";}
@@ -395,8 +399,7 @@ sub Do_operations {
 		    if ($wgt > 90) { $wgt = 90;}
 
 		    if ($debug) {print "weight=$wgt\n";}
-		    my $setweight = sprintf ("%c%c", 0x03, $wgt);
-		    $count = $port->write($setweight);
+		    $count = port_write(0x03, $wgt);
 
 		} elsif ($cmd eq "d") {  ## set PTT lead in (00...50)
                     my $delay = $arg;
@@ -405,8 +408,7 @@ sub Do_operations {
 
 		    if ($debug) { print "PTT lead in = $delay\n";}
                     my $delaybyte = int($delay / 10);
-		    $senddelay = sprintf ("%c%c%c", 0x04, $delaybyte, 0x00);
-		    $count = $port->write($senddelay);
+		    $count = port_write(0x04, $delaybyte, 0x00);
 
 		} elsif ($cmd eq "c") {     ## TUNE
 		    if ($tune_on) {
@@ -416,12 +418,10 @@ sub Do_operations {
 			$tune_on = 1;
 			if ($debug) { print "Tune on\n";}
 		    }
-		    my $tuning = sprintf("%c%c", 0x0B, $tune_on);
-		    $count = $port->write($tuning);
+		    $count = port_write(0x0B, $tune_on);
 
 		} else {
-		    my $stopkeying = sprintf("%c", 0x0A);
-		    $count = $port->write($stopkeying);
+		    $count = port_write(0x0A);      ## stop keying
                     @fifo = ();
 		    $tune_on = 0;
 		}
@@ -536,8 +536,7 @@ sub Do_operations {
         }
     }
 
-    my $keyerclose = sprintf ("%c%c", 0x00, 3);
-    $count = $port->write($keyerclose);
+    $count = port_write(0x00, 3);       ## close keyer
     undef $port;
     exit;
   }

--- a/src/winkeydaemon
+++ b/src/winkeydaemon
@@ -369,59 +369,46 @@ sub Do_operations {
 
 	    my @chars = split '', $datagram;
 	    if (ord($chars[0]) == 27) {
+                shift @chars;
+                my $cmd = shift @chars // '';
+                my $arg;
+                { no warnings; $arg = int(join '', @chars); }
 
-		if ($chars[1] eq "2") {		## set speed
-		    $speed = $chars[2];
-		    $speed = $speed .  $chars[3] if defined $chars[3];
+		if ($cmd eq "2") {          ## set speed
+		    $speed = $arg;
 		    if ($speed != 0) {
 			warn "Warning: can't set $speed WPM outside pot range: $minSpeed...$maxSpeed\n"
 			    unless (($minSpeed <= $speed) && ($speed <= $maxSpeed));
 		    }
+
+		    if ($debug) {print "setspeed=$speed\n";}
 		    $setspeed = sprintf ("%c%c", 0x02, $speed);
 		    $count = $port->write($setspeed);
-		    if ($debug) {print "setspeed=$speed\n";}
-		} elsif ($chars[1] eq "5") {  ## exit daemon
+
+		} elsif ($cmd eq "5") {     ## exit daemon
+		    if ($debug) {print "Exiting\n";}
 		    last;
-		} elsif ($chars[1] eq "7") {  ## set weight
-                    my $wgt;
-		    if ($chars[2] eq "-") {
-			$wgt = $chars[2] . $chars[3] ;
-			if ( defined $chars[4] ) {
-			    $wgt = $chars[2] . $chars[3] . $chars[4]
-				unless ord($chars[4]) == 0;
-			}
-		    } else {
-			    $wgt = $chars[2];
-			    if ( defined $chars[3] ) {
-				$wgt = $chars[2] . $chars[3]
-				    unless ord($chars[3]) == 0;
-			    }
-		    }
-		    $wgt += 50;
+
+		} elsif ($cmd eq "7") {     ## set weight
+                    my $wgt = 50 + $arg;
 		    if ($wgt < 10) { $wgt = 10;}
 		    if ($wgt > 90) { $wgt = 90;}
 
 		    if ($debug) {print "weight=$wgt\n";}
 		    my $setweight = sprintf ("%c%c", 0x03, $wgt);
 		    $count = $port->write($setweight);
-		} elsif ($chars[1] eq "d") {  ## set PTT lead in (00...50)
-                    my ($delay, $delaybyte);
-		    if (ord($chars[3]) == 0) {
-			$delay = 0;
-			$delaybyte = 0x02;
-		    } else {
-			$delay = $chars[2] . $chars[3];
-			$delaybyte = int ($delay / 10);
-				}
+
+		} elsif ($cmd eq "d") {  ## set PTT lead in (00...50)
+                    my $delay = $arg;
+                    if ($delay < 0) { $delay = 0;}
+                    if ($delay > 50) { $delay = 50;}
 
 		    if ($debug) { print "PTT lead in = $delay\n";}
-
-		    if ($delaybyte > 5) { $delaybyte = 5; }
-
+                    my $delaybyte = int($delay / 10);
 		    $senddelay = sprintf ("%c%c%c", 0x04, $delaybyte, 0x00);
 		    $count = $port->write($senddelay);
 
-		} elsif ($chars[1] eq "c") {  ## TUNE
+		} elsif ($cmd eq "c") {     ## TUNE
 		    if ($tune_on) {
 			$tune_on = 0;
 			if ($debug) { print "Tune off\n";}

--- a/src/winkeydaemon
+++ b/src/winkeydaemon
@@ -428,6 +428,7 @@ sub Do_operations {
 
 	    } else {
 		foreach my $c (@chars) {
+                    $c = uc($c);
 		    my $cr = ord($c);
                     # easy chars: 0-9 A-Z space ' ) / : < = > ? @ | backspace , .
                     if ($c =~ /^[0-9A-Z ')\/:<=>?@|\b,.]$/) {

--- a/src/winkeydaemon
+++ b/src/winkeydaemon
@@ -427,6 +427,7 @@ sub Do_operations {
 		}
 
 	    } else {
+                my $gap = 0;
 		foreach my $c (@chars) {
                     $c = uc($c);
 		    my $cr = ord($c);
@@ -454,8 +455,13 @@ sub Do_operations {
 		    } elsif ($cr == 0) {
 			last;
 		    }
-		    if ($debug > 1) {print $cr, "\n";}
 
+		    if ($c eq '~') {
+                        $gap = 1;
+                    } elsif ($gap) {
+                        push @fifo, ("|") x 4;
+                        $gap = 0;
+                    }
 		}
 
 		if ($debug) {print "Fifo: ",@fifo,"\n";}

--- a/src/winkeydaemon
+++ b/src/winkeydaemon
@@ -339,6 +339,7 @@ sub Do_operations {
     my $xoff = 0;
     my @fifo = ();
     my $tune_on = 0;
+    my $tune_end;
     my $datagram;
     my $saw;
 
@@ -411,14 +412,15 @@ sub Do_operations {
 		    $count = port_write(0x04, $delaybyte, 0x00);
 
 		} elsif ($cmd eq "c") {     ## TUNE
-		    if ($tune_on) {
-			$tune_on = 0;
-			if ($debug) { print "Tune off\n";}
-		    } else {
-			$tune_on = 1;
-			if ($debug) { print "Tune on\n";}
-		    }
-		    $count = port_write(0x0B, $tune_on);
+                    if ($arg > 0) {
+                        if ($arg > 10) { $arg = 10; }
+
+                        $tune_on = 1;
+                        $tune_end = time() + $arg;
+
+                        if ($debug) { print "Tune on\n";}
+                        $count = port_write(0x0B, 1);
+                    }
 
 		} else {
 		    $count = port_write(0x0A);      ## stop keying
@@ -468,6 +470,12 @@ sub Do_operations {
 
 	    }
 	}
+
+        if ($tune_on && time() > $tune_end) {   # stop tuning
+            $tune_on = 0;
+            if ($debug) { print "Tune off\n";}
+            $count = port_write(0x0B, 0);
+        }
 
         #
         # send chars if buffer is not full

--- a/src/winkeydaemon
+++ b/src/winkeydaemon
@@ -90,7 +90,7 @@ Prints version, then exists.
 use strict;
 use Pod::Usage qw(pod2usage);
 
-my $version = "1.0.9   30 Dec 2019";
+my $version = "1.0.10   26 Jan 2020";
 $main::VERSION = $version;
 $Getopt::Std::STANDARD_HELP_VERSION = '1';
 


### PR DESCRIPTION
Moved the evaluation of cwdaemon command argument to a common place. All supported commands have integer arguments, this simplifies parsing and no command-specific parsing is needed. Had to use `no warnings` or the built-in string-to-number conversion complained on non-digit chars.

Regarding setting PTT delay I'm not sure what the original intention was. For N<10 it set `$delaybyte = 0x02` (20 ms), but for N>=10 it took N/10 in accordance with WK specs. Now it takes always N/10, but this means for N<10 zero delay is set. An option would be to round to the nearest unit, e.g. take `int((N+5)/10)`.

Characters are now uppercased: sending lower case text - as in the man page - now actually works.

Added support for the (well, somewhat awkward) inter-char delay using tilde. cwdaemon adds 2 dit delay after the character that was prefixed with a `~`. WK also support extra space using `|` , but there the delay is 1/2 dit, so we add 4 pipes for a tilde. Multiple tildes don't add together, only a single extra space is generated as in cwdaemon.

One issue that is still outstanding: aligning the tune function. Currently command `c` toggles tuning state, whereas cwdeamon spec says that it shall tune for N seconds. This difference was also the root cause of the fix 4238940.

If this is OK with you, Nate, then I'll update tuning, and also bump version number.

